### PR TITLE
Update izneo_get.py

### DIFF
--- a/izneo_get.py
+++ b/izneo_get.py
@@ -408,7 +408,7 @@ if __name__ == "__main__":
         title_used = title
         if len(subtitle) > 0:
             title_used = title + " - " + subtitle
-        if len(subtitle) > 0 and len(tome) > 0:
+        if len(subtitle) > 0 and tome and len(tome) > 0:
             title_used = title + " - " + ("000" + tome)[-2:] + ". " + subtitle
         if len(subtitle) == 0 and len(tome) > 0:
             title_used = title + " - " + ("000" + tome)[-2:]


### PR DESCRIPTION
Dans le cadre de publications sous forme de chapitres, on a une erreur du type :
```
Traceback (most recent call last):
  File "izneo_get.py", line 411, in <module>
    if len(subtitle) > 0 and not tome and len(tome) > 0:
TypeError: object of type 'NoneType' has no len()
```
Avec ce test en plus, on peut continuer le téléchargement avec succès.
(Par exemple avec https://www.izneo.com/fr/manga-et-simultrad/josei/switch-me-on-27722/switch-me-on-chapitre-18-83284)