### PR TITLE
Allow for downloads of purchased content

### DIFF
--- a/izneo_get.py
+++ b/izneo_get.py
@@ -383,7 +383,7 @@ if __name__ == "__main__":
         )
         book_infos = json.loads(r.text)["data"]
 
-        is_abo = book_infos["state"] == "subscription"
+        is_abo = book_infos["state"] == "subscription" or "purchased"
 
         if not is_abo:
             print("Cette BD n'est pas disponible dans l'abonnement")


### PR DESCRIPTION
The current implementation throws an error for content that is not subscribed to, but has been instead purchased.

I looked at the JSON and it's because of the 'state' key is not 'subscription' but 'purchased. 

In my example:

```
{
  'userRating': 0,
  'state': 'purchased',
  'current': 4,
  'readDirection': 'ltr',
  'buyable': True,
  'title': 'Aldebaran',
  'subtitle': 'The Catastrophe',
  ...
}
```

The proposed change allows for downloads of purchased content.