### PR TITLE
Fix striping cbz from download dir cleanup

### DIFF
--- a/izneo_get/__main__.py
+++ b/izneo_get/__main__.py
@@ -102,7 +102,7 @@ def main() -> None:
             OutputFormat.BOTH,
         ]:
             if os.path.isdir(save_path):
-                expected_cbz_name = re.sub(".zip$", "", save_path, flags=re.IGNORECASE) + ".cbz"
+                expected_cbz_name = save_path + ".cbz"
                 if config.continue_from_existing and os.path.exists(expected_cbz_name):
                     print(f'File "{expected_cbz_name}" already exists.')
                 else:
@@ -110,7 +110,7 @@ def main() -> None:
                 result = expected_cbz_name
                 # If needed, we delete the folder.
                 if config.output_format == OutputFormat.CBZ:
-                    shutil.rmtree(re.sub(".zip$", "", save_path, flags=re.IGNORECASE))
+                    shutil.rmtree(save_path)
             else:
                 print(f'ERROR: "{save_path}" is not a folder.')
 


### PR DESCRIPTION
I expect string.strip(".cbz") was meant to remove only the trailing ".cbz" sequence of charcters. But strip(".cbz") removes any of '.', 'c', 'b' and 'z' from the start and end of the save_path.

As there is a check for save_path to be an existing directory it is thus not a cbz file. So remove strip(".cbz") altogether.

This fixes thefollowing error by not stripping the trailing 'z' from the save_path before remving its directory.

Create CBZ...
CBZ created: DOWNLOADS/<x>oz.cbz
Traceback (most recent call last):
  File "/home/prahal/Projects/WIP/Izneo/./izneo-get/izneo_get.py", line 5, in <module>
	main.main()
  File "/home/prahal/Projects/WIP/Izneo/izneo-get/izneo_get/main.py", line 109, in main
	shutil.rmtree(save_path.strip(".cbz"))
  File "/usr/lib/python3.11/shutil.py", line 722, in rmtree
	onerror(os.lstat, path, sys.exc_info())
  File "/usr/lib/python3.11/shutil.py", line 720, in rmtree
	orig_st = os.lstat(path, dir_fd=dir_fd)
			  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: 'DOWNLOADS/<x>o'