### PR TITLE
Fix obsolete regex syntax also for izneo_basket

### DIFF
--- a/izneo_basket.py
+++ b/izneo_basket.py
@@ -112,8 +112,8 @@ if __name__ == "__main__":
 
     if re.match(r"^http[s]://www.izneo.com/fr/panier-fin/(\d+)", url):
         # On est dans un cas où on a une URL de panier.
-        id = re.findall("(\d+)/", url)
+        id = re.findall(r"(\d+)/", url)
         if not id:
-            id = re.findall("(\d+)", url)
+            id = re.findall(r"(\d+)", url)
         id = id[0]
         parse_from_id(s, id)


### PR DESCRIPTION
Add "r" before regex stringto fix error.

Same as fix applied for izneo_list.py in commit d9c9484e1 "Suppression warning" from AUgust 2024.